### PR TITLE
Test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Each item can have various attributes, which all will be stored on the solr core
 
 The `id` attribute is special. Without an `id` attribute solr wil give the item an `id`. If you specify one (no matter where: as id or within the attributes) the solr core uses the given `id`.
 
+## Test
+
+Once configured you can test the service via command:
+
+	php artisan test:payload '{"data":"value"}'
+
 ## Configuration
 
 You have to configure various service options. Each of them are environment variables.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ The `id` attribute is special. Without an `id` attribute solr wil give the item 
 
 Once configured you can test the service via command:
 
-	php artisan test:payload '{"data":"value"}'
+	php artisan test:payload '{"id":"some-id"}' [expected-fields]
+	
+It will send the json object given as first argument to the solr.  
+If an `id` is included in the payload then the command verifies that the solr returns a document with the given id.  
+`expected-fields` is an optional comma-separated list. When given then the fields listed here are compared between the
+response from solr and the payload.
 
 ## Configuration
 

--- a/app/Console/Commands/TestPayloadCommand.php
+++ b/app/Console/Commands/TestPayloadCommand.php
@@ -77,10 +77,12 @@ class TestPayloadCommand extends Command
     	try {
 		    $this->checkPayloadInSolr($payload, $expectedFields);
     	} catch(\Exception $e) {
-    		$this->info($e->getMessage());
+    		$this->error($e->getMessage());
 
 		    return 2;
     	}
+
+    	$this->info('Test successful');
 
 		return 0;
     }
@@ -109,6 +111,12 @@ class TestPayloadCommand extends Command
 	 * @throws \Exception
 	 */
 	protected function checkPayloadInSolr(array $payload, array $expectedFields) {
+		if( !array_has($payload, 'id') ) {
+			$this->info('No `id` field in the payload. No verification that the data was received by solr.');
+
+			return;
+		}
+
 		$selectData = [
 			'query' => 'id:'.array_get($payload, 'id')
 		];

--- a/app/Console/Commands/TestPayloadCommand.php
+++ b/app/Console/Commands/TestPayloadCommand.php
@@ -7,6 +7,15 @@ use Ipunkt\LaravelIndexer\Jobs\Fake\FakeJob;
 use Ipunkt\LaravelIndexer\Jobs\Items\CreateItem;
 use Solarium\Client;
 
+/**
+ * Class TestPayloadCommand
+ * @package Ipunkt\LaravelIndexer\Console\Commands
+ *
+ * This command allows sending json data given as argument synchronously.
+ * It tests that the solr returns a document with the same id as the payload.
+ * If expected-fields are given as comma seperated list then the fields listed there are compared between the payload
+ *  and the document returned by solr.
+ */
 class TestPayloadCommand extends Command
 {
     /**

--- a/app/Console/Commands/TestPayloadCommand.php
+++ b/app/Console/Commands/TestPayloadCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Ipunkt\LaravelIndexer\Console\Commands;
+
+use Illuminate\Console\Command;
+use Ipunkt\LaravelIndexer\Jobs\Fake\FakeJob;
+use Ipunkt\LaravelIndexer\Jobs\Items\CreateItem;
+use Solarium\Client;
+
+class TestPayloadCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'test:payload {payload}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Test sending the payload given as argument to solr';
+	/**
+	 * @var Client
+	 */
+	private $client;
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @param Client $client
+	 */
+    public function __construct(Client $client) {
+        parent::__construct();
+	    $this->client = $client;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle() {
+
+    	$payload = $this->getPayload();
+
+    	$fakeJob = new FakeJob;
+
+    	$storeJob = new CreateItem( $payload );
+
+    	$storeJob->setJob($fakeJob);
+    	$storeJob->handle($this->client);
+
+	    /**
+	     * Job was released to try again - update was not successful
+	     */
+    	if( $fakeJob->isReleased() ) {
+    		$this->error("Job was released - sending the payload was not successful");
+
+		    return 1;
+	    }
+
+    	try {
+		    $this->checkPayloadInSolr($payload);
+    	} catch(\Exception $e) {
+    		$this->info($e->getMessage());
+
+		    return 2;
+    	}
+
+		return 0;
+    }
+
+	/**
+	 * @return array
+	 */
+	private function getPayload() {
+		$payloadData = $this->argument( 'payload' );
+
+		return json_decode( $payloadData, true );
+	}
+
+	/**
+	 * @param array $payload
+	 * @throws \Exception
+	 */
+	protected function checkPayloadInSolr(array $payload) {
+		$selectData = [
+			'query' => 'id:'.array_get($payload, 'id')
+		];
+
+		$select = $this->client->createSelect($selectData);
+
+		$result = $this->client->select($select);
+
+		if($result->getNumFound() < 1)
+			throw new \Exception('No document with the given id found.');
+		if($result->getNumFound() > 1)
+			throw new \Exception('More than one document with the given id found.');
+
+		$document = $result[0];
+
+		foreach ($payload as $key => $value) {
+			$solrValue = $document->${$key};
+			if( $solrValue != $value)
+				throw new \Exception("Field $key was not updated correctly: $$solrValue. Expected: $value");
+		}
+	}
+}

--- a/app/Console/Commands/TestPayloadCommand.php
+++ b/app/Console/Commands/TestPayloadCommand.php
@@ -100,11 +100,15 @@ class TestPayloadCommand extends Command
 		if($result->getNumFound() > 1)
 			throw new \Exception('More than one document with the given id found.');
 
-		$document = $result[0];
+		$array = $result->getIterator();
+		$document = $array->current();
 
 		foreach ($payload as $key => $value) {
-			$solrValue = $document->${$key};
-			if( $solrValue != $value)
+			if( !array_key_exists($key, $document->getFields()) )
+				throw new \Exception("Field $key does not exist in solr.");
+
+			$solrValue = array_get($document->getFields(), $key);
+			if( $solrValue != $value )
 				throw new \Exception("Field $key was not updated correctly: $$solrValue. Expected: $value");
 		}
 	}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,6 +4,7 @@ namespace Ipunkt\LaravelIndexer\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use Ipunkt\LaravelIndexer\Console\Commands\TestPayloadCommand;
 
 class Kernel extends ConsoleKernel
 {
@@ -13,7 +14,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+    	TestPayloadCommand::class,
     ];
 
     /**

--- a/app/Jobs/Fake/FakeJob.php
+++ b/app/Jobs/Fake/FakeJob.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Ipunkt\LaravelIndexer\Jobs\Fake;
+
+/**
+ * Class FakeJob
+ *
+ * This is NOT a Queue Job. Do NOT add it to the queue.
+ * It is used to retrieve successs information in the test:payload command.
+ */
+class FakeJob implements \Illuminate\Contracts\Queue\Job {
+	/**
+	 * @var bool
+	 */
+	private $released = false;
+
+	/**
+	 * @var int
+	 */
+	private $releaseDelay = 0;
+
+	/**
+	 * @var bool
+	 */
+	private $deleted = false;
+
+	/**
+	 * Fire the job.
+	 *
+	 * @return void
+	 */
+	public function fire() {
+	}
+
+	/**
+	 * Release the job back into the queue.
+	 *
+	 * @param  int $delay
+	 * @return mixed
+	 */
+	public function release( $delay = 0 ) {
+		$this->released = true;
+		$this->releaseDelay = $delay;
+	}
+
+	/**
+	 * Delete the job from the queue.
+	 *
+	 * @return void
+	 */
+	public function delete() {
+		$this->deleted = true;
+	}
+
+	/**
+	 * Determine if the job has been deleted.
+	 *
+	 * @return bool
+	 */
+	public function isDeleted() {
+		return $this->deleted;
+	}
+
+	/**
+	 * Determine if the job has been deleted or released.
+	 *
+	 * @return bool
+	 */
+	public function isDeletedOrReleased() {
+		return $this->released || $this->released;
+	}
+
+	/**
+	 * Get the number of times the job has been attempted.
+	 *
+	 * @return int
+	 */
+	public function attempts() {
+		return 0;
+	}
+
+	/**
+	 * Process an exception that caused the job to fail.
+	 *
+	 * @param  \Throwable $e
+	 * @return void
+	 */
+	public function failed( $e ) {
+	}
+
+	/**
+	 * The number of times to attempt a job.
+	 *
+	 * @return int|null
+	 */
+	public function maxTries() {
+		return 1;
+	}
+
+	/**
+	 * The number of seconds the job can run.
+	 *
+	 * @return int|null
+	 */
+	public function timeout() {
+		return null;
+	}
+
+	/**
+	 * Get the name of the queued job class.
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return null;
+	}
+
+	/**
+	 * Get the resolved name of the queued job class.
+	 *
+	 * Resolves the name of "wrapped" jobs such as class-based handlers.
+	 *
+	 * @return string
+	 */
+	public function resolveName() {
+		return null;
+	}
+
+	/**
+	 * Get the name of the connection the job belongs to.
+	 *
+	 * @return string
+	 */
+	public function getConnectionName() {
+		return null;
+	}
+
+	/**
+	 * Get the name of the queue the job belongs to.
+	 *
+	 * @return string
+	 */
+	public function getQueue() {
+		return null;
+	}
+
+	/**
+	 * Get the raw body string for the job.
+	 *
+	 * @return string
+	 */
+	public function getRawBody() {
+		return null;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isReleased(): bool {
+		return $this->released;
+	}
+}


### PR DESCRIPTION
Adds `test:payload` to test the solr connection with given payload data.

Possible test depths:
- Only payload given: Sends the data to solr
- Payload given including `id` field: Sends the data to solr and verifies that solr returns a document with that id
- Payload including `id` and `expected-fields` given as comma separated list: Compares the given fields between the payload and the response from solr