### PR TITLE
Composer install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ipunktbs/nginx:1.10.2-7-1.3.0
+FROM ipunktbs/nginx:1.10.2-7-1.4.0
 ADD . /var/www/app
 WORKDIR /var/www/app
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ipunktbs/nginx:1.10.2-7-1.3.0
 ADD . /var/www/app
 WORKDIR /var/www/app
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-	&& php -r "if (hash_file('SHA384', 'composer-setup.php') === '669656bab3166a7aff8a7506b8cb2d1c292f042046c5a994c43155c0be6190fa0355160742ab2e1c88d40d5be660b410') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+	&& php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('https://composer.github.io/installer.sig')) ) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
 	&& php composer-setup.php \
 	php -r "unlink('composer-setup.php');" \
 	&& cd /var/www/app && ./composer.phar install && rm composer.phar


### PR DESCRIPTION
Switched from hardcoded composer-setup.sh hash to the procedure described in https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md.
Small change from the link: used file_get_contents to retrieve the hash instead of wget.